### PR TITLE
Fix broken references to file upload variants

### DIFF
--- a/example/counter/tests/EndToEndTests.elm
+++ b/example/counter/tests/EndToEndTests.elm
@@ -32,8 +32,8 @@ config =
     , backendApp = Backend.app_
     , handleHttpRequest = always NetworkErrorResponse
     , handlePortToJs = always Nothing
-    , handleFileUpload = always CancelFileUpload
-    , handleMultipleFilesUpload = always CancelMultipleFilesUpload
+    , handleFileUpload = always UnhandledFileUpload
+    , handleMultipleFilesUpload = always UnhandledMultiFileUpload
     , domain = unsafeUrl
     }
 


### PR DESCRIPTION
When I ran the instructions in the repo and example folder (running `lamdera live` from `examples/counter` and going to `http://localhost:8000/tests/EndToEndTests.elm`), I got these errors:

```elm
-- NAMING ERROR  program-test/example/counter/tests/EndToEndTests.elm

I cannot find a `CancelFileUpload` variant:

35|     , handleFileUpload = always CancelFileUpload
                                    ^^^^^^^^^^^^^^^^
These names seem close though:

    UnhandledFileUpload
    UnhandledMultiFileUpload
    Dom.Viewport
    BadUrlResponse

Note: Evergreen migrations need access to all custom type variants. Make sure
both `CancelFileUpload` and `Evergreen.VX.CancelFileUpload` are exposed.

Hint: Read <https://elm-lang.org/0.19.1/imports> to see how `import`
declarations work in Elm.


-- NAMING ERROR  program-test/example/counter/tests/EndToEndTests.elm

I cannot find a `CancelMultipleFilesUpload` variant:

36|     , handleMultipleFilesUpload = always CancelMultipleFilesUpload
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
These names seem close though:

    UnhandledMultiFileUpload
    UploadMultipleFiles
    UnhandledFileUpload
    Effect.Test.UnhandledFileUpload

Note: Evergreen migrations need access to all custom type variants. Make sure
both `CancelMultipleFilesUpload` and `Evergreen.VX.CancelMultipleFilesUpload`
are exposed.

Hint: Read <https://elm-lang.org/0.19.1/imports> to see how `import`
declarations work in Elm.

```

Based on the types required here these seem to be the new variant names that are needed.